### PR TITLE
Add support for `open.spotify.com/embed` urls

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -45,6 +45,9 @@ function parse (uri) {
 
 function parseParts (parts, obj) {
   var len = parts.length;
+  if('embed' == parts[1]) {
+    parts = parts.slice(1, len);
+  }
   if ('search' == parts[1]) {
     obj.type = 'search';
     obj.query = decode(parts.slice(2).join(':'));

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,15 @@ describe('parse()', function () {
     });
   });
 
+  describe('"open.spotify.com/embed" URLs (e.g. twitter embed)', function () {
+    it('should parse "track" URLs', function () {
+      var url = 'https://open.spotify.com/embed/track/5oscsdDQ0NpjsTgpG4bI8S';
+      var obj = parse(url);
+      assert('track' == obj.type);
+      assert('5oscsdDQ0NpjsTgpG4bI8S' == obj.id);
+    });
+  });
+
   describe('Spotify URIs', function () {
     it('should parse "ablum" URIs', function () {
       var uri = 'spotify:album:4m2880jivSbbyEGAKfITCa';


### PR DESCRIPTION
These are for example provided as twitter players in the OpenGraph tags of a Spotify page.