### PR TITLE
Update parse.ts

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -90,5 +90,5 @@ function parseParts(uri: string, parts: string[]): ParsedSpotifyUri {
 	if (parts[1] === 'show') {
 		return new Show(uri, parts[2]);
 	}
-	throw new TypeError(`Could not determine type for: ${uri}`);
+	return null;
 }


### PR DESCRIPTION
Should return `null` if Spotify link is broken.