### PR TITLE
Typescript improvements / code deduplication

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+# Running locally
+To start contributing, install the packages using `npm install`. To ensure your changes are working, run `npm run build` followed by `npm run test` and all tests should pass.

--- a/src/album.ts
+++ b/src/album.ts
@@ -1,24 +1,7 @@
-import { encode } from './util'
 import SpotifyUri from './spotify-uri'
 
 export default class Album extends SpotifyUri {
-  public type = 'album'
-  public id: string
-
-  constructor (uri: string, id: string) {
-    super(uri)
-    this.id = id
-  }
-
   public static is (v: any): v is Album {
-    return Boolean(typeof v === 'object' && v.type === 'album')
-  }
-
-  public toURI (): string {
-    return `spotify:${this.type}:${encode(this.id)}`
-  }
-
-  public toURL (): string {
-    return `/${this.type}/${encode(this.id)}`
+    return typeof v === 'object' && v.type === 'album'
   }
 }

--- a/src/artist.ts
+++ b/src/artist.ts
@@ -1,24 +1,7 @@
-import { encode } from './util'
 import SpotifyUri from './spotify-uri'
 
 export default class Artist extends SpotifyUri {
-  public type = 'artist'
-  public id: string
-
-  constructor (uri: string, id: string) {
-    super(uri)
-    this.id = id
-  }
-
   public static is (v: any): v is Artist {
-    return Boolean(typeof v === 'object' && v.type === 'artist')
-  }
-
-  public toURI (): string {
-    return `spotify:${this.type}:${encode(this.id)}`
-  }
-
-  public toURL (): string {
-    return `/${this.type}/${encode(this.id)}`
+    return typeof v === 'object' && v.type === 'artist'
   }
 }

--- a/src/episode.ts
+++ b/src/episode.ts
@@ -1,24 +1,7 @@
-import { encode } from './util'
 import SpotifyUri from './spotify-uri'
 
 export default class Episode extends SpotifyUri {
-  public type = 'episode'
-  public id: string
-
-  constructor (uri: string, id: string) {
-    super(uri)
-    this.id = id
-  }
-
   public static is (v: any): v is Episode {
-    return Boolean(typeof v === 'object' && v.type === 'episode')
-  }
-
-  public toURI (): string {
-    return `spotify:${this.type}:${encode(this.id)}`
-  }
-
-  public toURL (): string {
-    return `/${this.type}/${encode(this.id)}`
+    return typeof v === 'object' && v.type === 'episode'
   }
 }

--- a/src/local.ts
+++ b/src/local.ts
@@ -1,8 +1,6 @@
-import { encode } from './util'
 import SpotifyUri from './spotify-uri'
-
+import { encode } from './util'
 export default class Local extends SpotifyUri {
-  public type = 'local'
   public artist: string
   public album: string
   public track: string
@@ -15,7 +13,7 @@ export default class Local extends SpotifyUri {
     track: string,
     seconds: number
   ) {
-    super(uri)
+    super(uri, "")
     this.artist = artist
     this.album = album
     this.track = track
@@ -23,14 +21,14 @@ export default class Local extends SpotifyUri {
   }
 
   public static is (v: any): v is Local {
-    return Boolean(typeof v === 'object' && v.type === 'local')
+    return typeof v === 'object' && v.type === 'local'
   }
 
   public toURI (): string {
-    return `spotify:local:${encode(this.artist)}:${encode(this.album)}:${encode(this.track)}:${this.seconds}`
+    return `spotify:${this.type}:${encode(this.artist)}:${encode(this.album)}:${encode(this.track)}:${this.seconds}`
   }
 
   public toURL (): string {
-    return `/local/${encode(this.artist)}/${encode(this.album)}/${encode(this.track)}/${this.seconds}`
+    return `/${this.type}/${encode(this.artist)}/${encode(this.album)}/${encode(this.track)}/${this.seconds}`
   }
 }

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -1,21 +1,17 @@
-import { encode } from './util'
 import SpotifyUri from './spotify-uri'
-
+import { encode } from './util'
 export default class Playlist extends SpotifyUri {
-  public type = 'playlist'
-  public id: string
   public user?: string
 
   constructor (uri: string, id: string, user?: string) {
-    super(uri)
-    this.id = id
+    super(uri, id)
     if (typeof user === 'string') {
       this.user = user
     }
   }
 
   public static is (v: any): v is Playlist {
-    return Boolean(typeof v === 'object' && v.type === 'playlist')
+    return typeof v === 'object' && v.type === 'playlist'
   }
 
   public toURI (): string {

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,24 +1,10 @@
-import { encode } from './util'
 import SpotifyUri from './spotify-uri'
 
 export default class Search extends SpotifyUri {
-  public type = 'search'
-  public query: string
-
-  constructor (uri: string, query: string) {
-    super(uri)
-    this.query = query
+  get query() {
+    return this.id;
   }
-
   public static is (v: any): v is Search {
-    return Boolean(typeof v === 'object' && v.type === 'search')
-  }
-
-  public toURI (): string {
-    return `spotify:search:${encode(this.query)}`
-  }
-
-  public toURL (): string {
-    return `/search/${encode(this.query)}`
+    return typeof v === 'object' && v.type === 'search'
   }
 }

--- a/src/show.ts
+++ b/src/show.ts
@@ -1,24 +1,7 @@
-import { encode } from './util'
 import SpotifyUri from './spotify-uri'
 
 export default class Show extends SpotifyUri {
-  public type = 'show'
-  public id: string
-
-  constructor (uri: string, id: string) {
-    super(uri)
-    this.id = id
-  }
-
   public static is (v: any): v is Show {
-    return Boolean(typeof v === 'object' && v.type === 'show')
-  }
-
-  public toURI (): string {
-    return `spotify:${this.type}:${encode(this.id)}`
-  }
-
-  public toURL (): string {
-    return `/${this.type}/${encode(this.id)}`
+    return typeof v === 'object' && v.type === 'show'
   }
 }

--- a/src/spotify-uri.ts
+++ b/src/spotify-uri.ts
@@ -1,14 +1,27 @@
-export default abstract class SpotifyUri {
-  public uri: string
-  public abstract toURL (): string
-  public abstract toURI (): string
+import { SpotifyTypes } from './types-enum';
+import { encode } from './util'
 
-  constructor (uri: string) {
-    this.uri = uri
+export default abstract class SpotifyUri {
+  public type: SpotifyTypes;
+  public id: string;
+  public uri: string;
+
+  constructor (uri: string, id : string) {
+    this.uri = uri;
+    this.id = id;
+    this.type = this.constructor.name.toLowerCase() as SpotifyTypes;
   }
 
   public static is (v: any): v is SpotifyUri {
-    return Boolean(typeof v === 'object' && typeof v.uri === 'string')
+    return typeof v === 'object' && typeof v.uri === 'string'
+  }
+
+  public toURI (): string {
+    return `spotify:${this.type}:${encode(this.id)}`
+  }
+
+  public toURL (): string {
+    return `/${this.type}/${encode(this.id)}`
   }
 
   public toEmbedURL (): string {

--- a/src/track.ts
+++ b/src/track.ts
@@ -1,24 +1,7 @@
-import { encode } from './util'
 import SpotifyUri from './spotify-uri'
 
 export default class Track extends SpotifyUri {
-  public type = 'track'
-  public id: string
-
-  constructor (uri: string, id: string) {
-    super(uri)
-    this.id = id
-  }
-
   public static is (v: any): v is Track {
-    return Boolean(typeof v === 'object' && v.type === 'track')
-  }
-
-  public toURI (): string {
-    return `spotify:${this.type}:${encode(this.id)}`
-  }
-
-  public toURL (): string {
-    return `/${this.type}/${encode(this.id)}`
+    return typeof v === 'object' && v.type === 'track'
   }
 }

--- a/src/types-enum.ts
+++ b/src/types-enum.ts
@@ -1,0 +1,12 @@
+export enum SpotifyTypes {
+    Album = 'album',
+    Artist = 'artist',
+    Episode = 'episode',
+    Local = 'local',
+    Playlist = 'playlist',
+    Search = 'search',
+    Show = 'show',
+    Track = 'track',
+    User = 'user',
+    Embed = 'embed'
+}

--- a/src/user.ts
+++ b/src/user.ts
@@ -1,24 +1,10 @@
-import { encode } from './util'
 import SpotifyUri from './spotify-uri'
 
 export default class User extends SpotifyUri {
-  public type = 'user'
-  public user: string
-
-  constructor (uri: string, user: string) {
-    super(uri)
-    this.user = user
+  get user() {
+    return this.id;
   }
-
   public static is (v: any): v is User {
-    return Boolean(typeof v === 'object' && v.type === 'user')
-  }
-
-  public toURI (): string {
-    return `spotify:${this.type}:${encode(this.user)}`
-  }
-
-  public toURL (): string {
-    return `/${this.type}/${encode(this.user)}`
+    return typeof v === 'object' && v.type === 'user'
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,7 +5,7 @@
  * @api private
  */
 export function decode (str: string): string {
-  return decodeURIComponent(str).replace(/\+/g, ' ')
+  return decodeURIComponent(str.replace(/\+/g, ' '))
 }
 
 /**
@@ -15,5 +15,5 @@ export function decode (str: string): string {
  * @api private
  */
 export function encode (str: string): string {
-  return escape(str.replace(/ /g, '+'))
+  return encodeURIComponent(str).replace(/%20/g, "+").replace(/[!'()*]/g, escape)
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "module": "CommonJS",
-    "target": "es2015",
+    "target": "esnext",
     "esModuleInterop": true,
     "lib": ["esnext"],
     "outDir": "dist",


### PR DESCRIPTION
- **Biggest change:** Move duplicate functionality back to inherited `SpotifyUri` class since almost all of it is copy pasted across the different types, and make a few special exceptions where a different property name was expected over 'id' ex(`.user`)
    - This should not have any breaking changes, except for that the `.type` is now an enum if someone had explicitly referenced it as a string
- Start a contributing guide 
- Make 'encode' less reliant on the escape function
- Create new SpotifyTypes array to refer to them by type instead of having to know the string
- Fix invalid jsdoc for parse