### PR TITLE
Ignore URLs with localization 

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -47,6 +47,8 @@ export default function parse (input: string | SpotifyUri): ParsedSpotifyUri {
 }
 
 function parseParts (uri: string, parts: string[]): ParsedSpotifyUri {
+  parts = parts.filter(p => !p.startsWith('intl'))
+
   let spotifyType = parts[1]
   if (spotifyType === SpotifyTypes.Embed) {
     parts = parts.slice(1)

--- a/test/test.js
+++ b/test/test.js
@@ -18,14 +18,32 @@ describe('parse()', function () {
       assert.strictEqual('track', obj.type)
       assert.strictEqual('10M2REwwztVxgr0szw7UwD', obj.id)
     })
+    it('should parse "track" URLs with localization', function () {
+      const url = 'https://open.spotify.com/intl-il/track/4uhnhRlZ1Jq5zN7VOxqHeW'
+      const obj = parse(url)
+      assert.strictEqual('track', obj.type)
+      assert.strictEqual('4uhnhRlZ1Jq5zN7VOxqHeW', obj.id)
+    })
     it('should parse "episode" URLs', function () {
       const url = 'http://open.spotify.com/episode/64TORH3xleuD1wcnFsrH1E'
       const obj = parse(url)
       assert.strictEqual('episode', obj.type)
       assert.strictEqual('64TORH3xleuD1wcnFsrH1E', obj.id)
     })
+    it('should parse "episode" URLs with localization', function () {
+      const url = 'http://open.spotify.com/intl-il/episode/64TORH3xleuD1wcnFsrH1E'
+      const obj = parse(url)
+      assert.strictEqual('episode', obj.type)
+      assert.strictEqual('64TORH3xleuD1wcnFsrH1E', obj.id)
+    })
     it('should parse "show" URLs', function () {
       const url = 'https://open.spotify.com/show/6uxKcBftLv1aOWoNL7UzTl'
+      const obj = parse(url)
+      assert.strictEqual('show', obj.type)
+      assert.strictEqual('6uxKcBftLv1aOWoNL7UzTl', obj.id)
+    })
+    it('should parse "show" URLs with localization', function () {
+      const url = 'https://open.spotify.com/intl-il/show/6uxKcBftLv1aOWoNL7UzTl'
       const obj = parse(url)
       assert.strictEqual('show', obj.type)
       assert.strictEqual('6uxKcBftLv1aOWoNL7UzTl', obj.id)
@@ -87,6 +105,12 @@ describe('parse()', function () {
       assert.strictEqual('track', obj.type)
       assert.strictEqual('5W3cjX2J3tjhG8zb6u0qHn', obj.id)
     })
+    it('should parse "track" URLs with localization', function () {
+      const url = 'https://play.spotify.com/intl-fr/track/4uhnhRlZ1Jq5zN7VOxqHeW'
+      const obj = parse(url)
+      assert.strictEqual('track', obj.type)
+      assert.strictEqual('4uhnhRlZ1Jq5zN7VOxqHeW', obj.id)
+    })
   })
 
   describe('"embed.spotify.com" URLs', function () {
@@ -113,9 +137,22 @@ describe('parse()', function () {
       assert.strictEqual('track', obj.type)
       assert.strictEqual('5oscsdDQ0NpjsTgpG4bI8S', obj.id)
     })
+    it('should parse "track" URLs with localization', function () {
+      const url = 'https://open.spotify.com/embed/intl-il/track/5oscsdDQ0NpjsTgpG4bI8S'
+      const obj = parse(url)
+      assert.strictEqual('track', obj.type)
+      assert.strictEqual('5oscsdDQ0NpjsTgpG4bI8S', obj.id)
+    })
     it('should parse "playlist" URLs', function () {
       const url =
         'https://open.spotify.com/embed/playlist/7arbVhvtYYaLYJefoRBSvU'
+      const obj = parse(url)
+      assert.strictEqual('playlist', obj.type)
+      assert.strictEqual('7arbVhvtYYaLYJefoRBSvU', obj.id)
+    })
+    it('should parse "playlist" URLs with localization', function () {
+      const url =
+        'https://open.spotify.com/intl-il/embed/playlist/7arbVhvtYYaLYJefoRBSvU'
       const obj = parse(url)
       assert.strictEqual('playlist', obj.type)
       assert.strictEqual('7arbVhvtYYaLYJefoRBSvU', obj.id)


### PR DESCRIPTION
Spotify recently started adopting a localization format in their URLs, that adds a "/intl-<country>" bit to every URL.
This change appears to break a few packages that depend on `spotify-uri`.
This PR ignores the /intl-<countryCode>/ part of the URLs that spotify has recently started adopting. 

Alternatively, we could also add the country code to the return object of the `parse` function, but I opted for a quick-fix for now. 

I'd love to get feedback on this.

